### PR TITLE
リダイレクトがうまくされないバグを解消

### DIFF
--- a/app/views/groups/new.html.erb
+++ b/app/views/groups/new.html.erb
@@ -14,7 +14,7 @@
       <%= f.text_field :name, class: 'form-control' %>
     </div>
 
-    <%= f.submit class: 'btn btn-success me-2' %>
+    <%= f.submit class: 'btn btn-success me-2', data: { turbo: false } %>
     <%= link_to 'キャンセル', root_path, class: 'btn btn-secondary' %>
   <% end %>
 <% end %>


### PR DESCRIPTION
turboを無効化しないとredirect処理がうまく走らない